### PR TITLE
feat(ai): 自定义 AI 能力提供商新增 OpenCode Zen 与 OpenCode Go

### DIFF
--- a/lib/ai/constants.ts
+++ b/lib/ai/constants.ts
@@ -1439,6 +1439,148 @@ export const AI_PROVIDER_CATALOG: AIProviderOption[] = [
         ]
     },
     {
+        id: 'opencode-zen',
+        name: 'OpenCode Zen',
+        description: 'OpenCode 官方 AI 网关，聚合经团队实测的 DeepSeek / GLM / Kimi / MiniMax 等模型，按量计费。',
+        docsUrl: 'https://opencode.ai/auth',
+        baseUrl: 'https://opencode.ai/zen/v1',
+        type: 'openai',
+        mode: 'auto',
+        models: [
+            {
+                value: 'deepseek-v4-flash',
+                label: 'DeepSeek V4 Flash',
+                description: 'DeepSeek V4 Flash，Agent 能力大幅增强，百万级上下文，兼顾质量与成本。'
+            },
+            {
+                value: 'deepseek-v4-pro',
+                label: 'DeepSeek V4 Pro',
+                description: 'DeepSeek V4 完全体，适合复杂分析、长文本写作与高质量生成。'
+            },
+            {
+                value: 'glm-5.2',
+                label: 'GLM-5.2',
+                description: '智谱开源旗舰模型，支持 1M 无损上下文，编程能力领先，适合复杂长程任务。'
+            },
+            {
+                value: 'glm-5.1',
+                label: 'GLM-5.1',
+                description: '智谱通用模型，综合能力均衡，适合复杂指令、多轮对话与高质量创作。'
+            },
+            {
+                value: 'glm-5',
+                label: 'GLM-5',
+                description: '智谱通用模型，适合中文对话、总结与结构化输出。'
+            },
+            {
+                value: 'kimi-k3',
+                label: 'Kimi K3',
+                description: 'Moonshot 旗舰模型，1M token 上下文，综合智能领先，适合长程编程与端到端知识工作。'
+            },
+            {
+                value: 'kimi-k2.7-code',
+                label: 'Kimi K2.7 Code',
+                description: 'Moonshot 面向编程场景的模型，长上下文指令遵循更可靠。'
+            },
+            {
+                value: 'kimi-k2.6',
+                label: 'Kimi K2.6',
+                description: 'Moonshot 通用模型，适合中文创作、角色设定、摘要与多轮指令跟随。'
+            },
+            {
+                value: 'kimi-k2.5',
+                label: 'Kimi K2.5',
+                description: 'Moonshot 原生多模态模型，适合中文创作、摘要与多轮指令跟随。'
+            },
+            {
+                value: 'minimax-m3',
+                label: 'MiniMax M3',
+                description: 'MiniMax 多模态旗舰模型，适合复杂 Agent 工作流与长程任务。'
+            },
+            {
+                value: 'minimax-m2.7',
+                label: 'MiniMax M2.7',
+                description: 'MiniMax 通用模型，适合复杂规划、长链路任务与高质量文本生成。'
+            },
+            {
+                value: 'big-pickle',
+                label: 'Big Pickle（免费）',
+                description: 'OpenCode Zen 提供的免费实验模型，处于实验期，不建议发送敏感或私密数据。'
+            },
+            {
+                value: 'deepseek-v4-flash-free',
+                label: 'DeepSeek V4 Flash（免费）',
+                description: 'OpenCode Zen 限时免费的 DeepSeek V4 Flash，适合低成本尝试。'
+            },
+        ]
+    },
+    {
+        id: 'opencode-go',
+        name: 'OpenCode Go',
+        description: 'OpenCode 官方低价订阅（首月 $5，之后 $10/月），稳定访问主流开源编码模型。',
+        docsUrl: 'https://opencode.ai/auth',
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        type: 'openai',
+        mode: 'auto',
+        models: [
+            {
+                value: 'deepseek-v4-flash',
+                label: 'DeepSeek V4 Flash',
+                description: 'DeepSeek V4 Flash，Agent 能力大幅增强，百万级上下文，兼顾质量与成本。'
+            },
+            {
+                value: 'deepseek-v4-pro',
+                label: 'DeepSeek V4 Pro',
+                description: 'DeepSeek V4 完全体，适合复杂分析、长文本写作与高质量生成。'
+            },
+            {
+                value: 'glm-5.3',
+                label: 'GLM-5.3',
+                description: '智谱通用模型，综合能力均衡，适合复杂指令、多轮对话与高质量创作。'
+            },
+            {
+                value: 'glm-5.2',
+                label: 'GLM-5.2',
+                description: '智谱开源旗舰模型，支持 1M 无损上下文，编程能力领先，适合复杂长程任务。'
+            },
+            {
+                value: 'glm-5.1',
+                label: 'GLM-5.1',
+                description: '智谱通用模型，综合能力均衡，适合复杂指令、多轮对话与高质量创作。'
+            },
+            {
+                value: 'kimi-k3',
+                label: 'Kimi K3',
+                description: 'Moonshot 旗舰模型，1M token 上下文，综合智能领先，适合长程编程与端到端知识工作。'
+            },
+            {
+                value: 'kimi-k2.7-code',
+                label: 'Kimi K2.7 Code',
+                description: 'Moonshot 面向编程场景的模型，长上下文指令遵循更可靠。'
+            },
+            {
+                value: 'kimi-k2.6',
+                label: 'Kimi K2.6',
+                description: 'Moonshot 通用模型，适合中文创作、角色设定、摘要与多轮指令跟随。'
+            },
+            {
+                value: 'mimo-v2.5',
+                label: 'MiMo V2.5',
+                description: '小米 MiMo V2.5 通用模型，适合日常对话、剧情推进与结构化文本生成。'
+            },
+            {
+                value: 'mimo-v2.5-pro',
+                label: 'MiMo V2.5 Pro',
+                description: '小米 MiMo V2.5 Pro，适合复杂指令、长文本创作与高质量生成。'
+            },
+            {
+                value: 'hy3',
+                label: '混元 Hy3',
+                description: '腾讯混元通用模型，提供多档思考模式，适合复杂任务执行。'
+            },
+        ]
+    },
+    {
         id: 'mystery',
         name: '魔法国度',
         description: '神秘渠道，不定时放送。',

--- a/lib/ai/constants.ts
+++ b/lib/ai/constants.ts
@@ -1563,16 +1563,7 @@ export const AI_PROVIDER_CATALOG: AIProviderOption[] = [
                 label: 'Kimi K2.6',
                 description: 'Moonshot 通用模型，适合中文创作、角色设定、摘要与多轮指令跟随。'
             },
-            {
-                value: 'mimo-v2.5',
-                label: 'MiMo V2.5',
-                description: '小米 MiMo V2.5 通用模型，适合日常对话、剧情推进与结构化文本生成。'
-            },
-            {
-                value: 'mimo-v2.5-pro',
-                label: 'MiMo V2.5 Pro',
-                description: '小米 MiMo V2.5 Pro，适合复杂指令、长文本创作与高质量生成。'
-            },
+            ...XIAOMI_MIMO_MODELS,
             {
                 value: 'hy3',
                 label: '混元 Hy3',

--- a/tests/opencode-providers.test.ts
+++ b/tests/opencode-providers.test.ts
@@ -2,40 +2,37 @@ import { describe, expect, it } from 'vitest';
 
 import { AI_PROVIDER_CATALOG } from '@/lib/ai/constants';
 
-const getProvider = (id: string) => AI_PROVIDER_CATALOG.find((provider) => provider.id === id);
+const getProvider = (providerId: string) => {
+  const provider = AI_PROVIDER_CATALOG.find((item) => item.id === providerId);
+  if (!provider) throw new Error(`missing provider fixture: ${providerId}`);
+  return provider;
+};
 
 describe('opencode providers', () => {
   it('OpenCode Zen 已注册且配置正确', () => {
     const zen = getProvider('opencode-zen');
-    expect(zen).toBeDefined();
-    expect(zen?.type).toBe('openai');
-    expect(zen?.baseUrl).toBe('https://opencode.ai/zen/v1');
-    expect(zen?.docsUrl).toBe('https://opencode.ai/auth');
-    expect(zen?.models.length).toBeGreaterThan(0);
+    expect(zen.type).toBe('openai');
+    expect(zen.baseUrl).toBe('https://opencode.ai/zen/v1');
+    expect(zen.docsUrl).toBe('https://opencode.ai/auth');
+    expect(zen.models.length).toBeGreaterThan(0);
   });
 
   it('OpenCode Go 已注册且配置正确', () => {
     const go = getProvider('opencode-go');
-    expect(go).toBeDefined();
-    expect(go?.type).toBe('openai');
-    expect(go?.baseUrl).toBe('https://opencode.ai/zen/go/v1');
-    expect(go?.docsUrl).toBe('https://opencode.ai/auth');
-    expect(go?.models.length).toBeGreaterThan(0);
+    expect(go.type).toBe('openai');
+    expect(go.baseUrl).toBe('https://opencode.ai/zen/go/v1');
+    expect(go.docsUrl).toBe('https://opencode.ai/auth');
+    expect(go.models.length).toBeGreaterThan(0);
   });
 
-  it('两个新增 provider 的模型列表互不冲突且非空', () => {
-    const zen = getProvider('opencode-zen');
-    const go = getProvider('opencode-go');
-    const zenValues = new Set(zen?.models.map((model) => model.value));
-    const goValues = new Set(go?.models.map((model) => model.value));
-
-    expect(zenValues.size).toBe(zen?.models.length);
-    expect(goValues.size).toBe(go?.models.length);
-    for (const value of zenValues) {
-      expect(value.trim().length).toBeGreaterThan(0);
-    }
-    for (const value of goValues) {
-      expect(value.trim().length).toBeGreaterThan(0);
+  it('两个新增 provider 的模型列表非空且各自 value 唯一', () => {
+    for (const provider of [getProvider('opencode-zen'), getProvider('opencode-go')]) {
+      expect(provider.models.length).toBeGreaterThan(0);
+      const values = provider.models.map((model) => model.value);
+      for (const value of values) {
+        expect(value.trim().length).toBeGreaterThan(0);
+      }
+      expect(new Set(values).size).toBe(values.length);
     }
   });
 });

--- a/tests/opencode-providers.test.ts
+++ b/tests/opencode-providers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { AI_PROVIDER_CATALOG } from '@/lib/ai/constants';
+
+const getProvider = (id: string) => AI_PROVIDER_CATALOG.find((provider) => provider.id === id);
+
+describe('opencode providers', () => {
+  it('OpenCode Zen 已注册且配置正确', () => {
+    const zen = getProvider('opencode-zen');
+    expect(zen).toBeDefined();
+    expect(zen?.type).toBe('openai');
+    expect(zen?.baseUrl).toBe('https://opencode.ai/zen/v1');
+    expect(zen?.docsUrl).toBe('https://opencode.ai/auth');
+    expect(zen?.models.length).toBeGreaterThan(0);
+  });
+
+  it('OpenCode Go 已注册且配置正确', () => {
+    const go = getProvider('opencode-go');
+    expect(go).toBeDefined();
+    expect(go?.type).toBe('openai');
+    expect(go?.baseUrl).toBe('https://opencode.ai/zen/go/v1');
+    expect(go?.docsUrl).toBe('https://opencode.ai/auth');
+    expect(go?.models.length).toBeGreaterThan(0);
+  });
+
+  it('两个新增 provider 的模型列表互不冲突且非空', () => {
+    const zen = getProvider('opencode-zen');
+    const go = getProvider('opencode-go');
+    const zenValues = new Set(zen?.models.map((model) => model.value));
+    const goValues = new Set(go?.models.map((model) => model.value));
+
+    expect(zenValues.size).toBe(zen?.models.length);
+    expect(goValues.size).toBe(go?.models.length);
+    for (const value of zenValues) {
+      expect(value.trim().length).toBeGreaterThan(0);
+    }
+    for (const value of goValues) {
+      expect(value.trim().length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## 范围

根据 issue #52 的诉求，在「自定义 AI 能力提供商」目录（`lib/ai/constants.ts` 的 `AI_PROVIDER_CATALOG`）中新增两个 OpenAI 兼容供应商：

- **OpenCode Zen**（`opencode-zen`）：`https://opencode.ai/zen/v1`，按量计费。
- **OpenCode Go**（`opencode-go`）：`https://opencode.ai/zen/go/v1`，订阅制（首月 $5，之后 $10/月）。

两者均走 OpenAI 兼容的 `chat/completions` 端点，与项目现有 `type: "openai"` 通道一致（`@ai-sdk/openai` 的 `.chat()` 调用），因此仅预设了走该端点可用的模型（DeepSeek V4、GLM、Kimi、MiniMax、MiMo、Hy3、Big Pickle 等），未包含走 `/responses`（GPT、Grok）或 `/messages`（Claude、部分 Qwen/MiniMax）的模型。

新增测试 `tests/opencode-providers.test.ts`，校验两个 provider 的 baseUrl / type / docsUrl 及模型列表非空、唯一。

## 已执行的命令

- `pnpm test`：305 个测试文件、1615 个测试全部通过
- `pnpm lint`：无 ESLint 告警或错误
- `pnpm build`：编译成功（Compiled successfully）

## 仍未验证的部分

- 未使用真实的 OpenCode Zen / Go API Key 进行端到端调用验证；端点与模型 ID 均来自 OpenCode 官方文档（https://opencode.ai/docs/zen 、https://opencode.ai/docs/go）。
- 未为新增模型登记 `model-capabilities.ts`（temperature / thinking / maxOutputTokens），遵循仓库「不猜测」策略，未登记项返回 unknown，由生成设置 Resolver 按保守方式处理。
